### PR TITLE
Customizeable json.loads() arguments

### DIFF
--- a/jsonrpc_requests/jsonrpc.py
+++ b/jsonrpc_requests/jsonrpc.py
@@ -61,11 +61,13 @@ class Server(object):
         if not is_notification:
             return self.parse_response(response)
 
-    @staticmethod
-    def parse_response(response):
+    def set_loads_kwargs(self, **kwargs):
+        self.loads_kwargs = kwargs
+        
+    def parse_response(self, response):
         """Parse the data returned by the server according to the JSON-RPC spec. Try to be liberal in what we accept."""
         try:
-            server_data = response.json()
+            server_data = response.json(**self.loads_kwargs)
         except ValueError as value_error:
             raise ProtocolError('Cannot deserialize response body: %s' % value_error, server_response=response)
 


### PR DESCRIPTION
Allow customization of json.loads() arguments, for example: parse_float=decimal.Decimal