### PR TITLE
Allow overriding the way json parsing is done

### DIFF
--- a/jsonrpc_requests/jsonrpc.py
+++ b/jsonrpc_requests/jsonrpc.py
@@ -61,11 +61,14 @@ class Server(object):
         if not is_notification:
             return self.parse_response(response)
 
-    @staticmethod
-    def parse_response(response):
+    def loads(self, response):
+        """Override this method to customize the json deserialization process (eg. float handling)"""
+        return response.json()
+
+    def parse_response(self, response):
         """Parse the data returned by the server according to the JSON-RPC spec. Try to be liberal in what we accept."""
         try:
-            server_data = response.json()
+            server_data = self.loads(response)
         except ValueError as value_error:
             raise ProtocolError('Cannot deserialize response body: %s' % value_error, server_response=response)
 


### PR DESCRIPTION
Allow overriding the way json parsing is done. Example usage:

```
class JSONRPC_Server(jsonrpc_requests.Server):

    # override the loads method:
    def loads(self, response):
        return response.json(parse_float = decimal.Decimal)
```

This will make requests pass `parse_float = decimal.Decimal` to json.loads, which will make it parse all floats into decimal.Decimals rather than normal floats. This in turn makes it possible to avoid the very real rounding/precision errors that otherwise happens with returned bitcoin values when converting to satoshis (for example with decoderawtransaction)
